### PR TITLE
feat: スタート画面（ゲーム開始時に1度だけ表示される）の実装

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import Welcome from './components/Welcome';
 import WindowSelector from './components/WindowSelector';
 import ZoomAnimation from './components/ZoomAnimation';
 import PhotoDisplay from './components/PhotoDisplay';
@@ -9,6 +10,7 @@ import { theme } from './styles/theme';
 function App() {
   const {
     gameState,
+    startWelcome,
     startGame,
     completeZoom,
     showMap,
@@ -51,6 +53,10 @@ function App() {
       </div>
 
       {/* ステージに応じてコンポーネント表示 */}
+      {gameState.gameStage === 'welcome' && (
+        <Welcome onStartGame={startWelcome} />
+      )}
+
       {gameState.gameStage === 'waitingToStart' && (
         <WindowSelector onWindowClick={startGame} />
       )}

--- a/src/components/Welcome.tsx
+++ b/src/components/Welcome.tsx
@@ -1,0 +1,89 @@
+import { commonStyles, theme } from '../styles/theme';
+
+interface WelcomeProps {
+    onStartGame: () => void;
+}
+
+export default function Welcome({ onStartGame }: WelcomeProps) {
+    return (
+        <div style={commonStyles.container}>
+            <h1 style={{
+                fontSize: '3em',
+                fontWeight: '300',
+                color: theme.colors.starWhite,
+                marginBottom: theme.spacing.lg,
+                textTransform: 'uppercase',
+                letterSpacing: '0.1em'
+            }}>
+                CupolaQuest
+            </h1>
+
+            <div style={{
+                maxWidth: '600px',
+                margin: '0 auto',
+                textAlign: 'center'
+            }}>
+                <p style={{
+                    fontSize: '1.2em',
+                    color: theme.colors.starSilver,
+                    marginBottom: theme.spacing.xl,
+                    lineHeight: '1.6'
+                }}>
+                    ISSの展望モジュール「Cupola」から撮影された地球の写真を見て、
+                    <br />
+                    どこを撮影したのかを当てるゲームです。
+                </p>
+
+                <div style={{
+                    background: `${theme.colors.spaceBlue}40`,
+                    padding: theme.spacing.xl,
+                    borderRadius: theme.borderRadius.md,
+                    border: `1px solid ${theme.shadows.border}`,
+                    marginBottom: theme.spacing.xl
+                }}>
+                    <h3 style={{
+                        fontSize: '1.1em',
+                        color: theme.colors.starWhite,
+                        marginBottom: theme.spacing.md
+                    }}>
+                        ゲームの流れ
+                    </h3>
+                    <div style={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        gap: theme.spacing.sm,
+                        textAlign: 'left'
+                    }}>
+                        <p style={{ color: theme.colors.starSilver, fontSize: '0.9em' }}>
+                            1. Cupola窓をクリックしてゲーム開始
+                        </p>
+                        <p style={{ color: theme.colors.starSilver, fontSize: '0.9em' }}>
+                            2. ISSから撮影された地球の写真を確認
+                        </p>
+                        <p style={{ color: theme.colors.starSilver, fontSize: '0.9em' }}>
+                            3. 地図上で撮影場所を推測
+                        </p>
+                        <p style={{ color: theme.colors.starSilver, fontSize: '0.9em' }}>
+                            4. 距離と回答時間でスコア計算
+                        </p>
+                    </div>
+                </div>
+
+                <button
+                    onClick={onStartGame}
+                    style={{
+                        ...commonStyles.button,
+                        padding: `${theme.spacing.lg} ${theme.spacing.xxl}`,
+                        fontSize: '1.1em',
+                        fontWeight: '500',
+                        background: theme.colors.accentBlue,
+                        border: `1px solid ${theme.colors.accentBlue}`,
+                        minWidth: '200px'
+                    }}
+                >
+                    Start Game
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -9,10 +9,17 @@ export function useGameState() {
         userAnswer: null,
         score: null,
         answerTime: null,
-        gameStage: 'waitingToStart'
+        gameStage: 'welcome'
     });
 
     const [gameStartTime, setGameStartTime] = useState<number | null>(null);
+
+    const startWelcome = () => {
+        setGameState({
+            ...gameState,
+            gameStage: 'waitingToStart'
+        });
+    };
 
     const startGame = () => {
         const randomQuestion = getRandomQuestion();
@@ -84,6 +91,7 @@ export function useGameState() {
 
     return {
         gameState,
+        startWelcome,
         startGame,
         completeZoom,
         showMap,

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,7 @@ export interface UserAnswer {
 
 // ゲームステージ
 export type GameStage =
+    | 'welcome'             // スタート画面（初回のみ）
     | 'waitingToStart'      // 開始を待機中
     | 'zoomingToPhoto'      // 写真にズーム中
     | 'viewingPhoto'        // 写真を表示中


### PR DESCRIPTION
## 概要
ゲーム開始時に表示されるスタート画面を追加しました。
初回のみ表示され、クイズ終了後時はwaitingToStart状態に戻る仕様です。（詳しくは下の「画面遷移フロー」を読んでください）

## 画面遷移フロー
**初回**:
1. スタート画面 (welcome)
2. クイズ開始待機画面 (waitingToStart)
3. ゲーム開始

**2回目以降**:
1. スコア表示
2. クイズ開始待機画面 (waitingToStart)
3. ゲーム開始

## 技術的詳細

### 新規ファイル
- `src/components/Welcome.tsx`: スタート画面コンポーネント

### 変更ファイル
- `src/types.ts`: GameStage型の拡張
- `src/hooks/useGameState.ts`: 状態管理の更新
- `src/App.tsx`: コンポーネント表示ロジックの追加